### PR TITLE
更正scws在FreeBSD下的编译问题

### DIFF
--- a/xunsearch-full/setup.sh
+++ b/xunsearch-full/setup.sh
@@ -48,6 +48,7 @@ set_force="no"
 set_no_clean="no"
 mk_add_option=
 xs_add_option=
+freebsd= `uname -a | grep FreeBSD`
 
 i=0
 while [ $i -lt $# ] ; do
@@ -138,8 +139,13 @@ prefix=$set_prefix
 echo $prefix > $HOME/.xs_installed
 
 # compile flags
-export CFLAGS=-O2
-export CXXFLAGS=-O2
+if test -n "$freebsd" then
+  export CFLAGS="-O2 -fPIC"
+  export CXXFLAGS="-O2 -fPIC"
+else 
+  export CFLAGS="-O2"
+  export CXXFLAGS="-O2"
+fi
 echo -n > setup.log
 
 # error function
@@ -184,7 +190,11 @@ if test "$do_install" = "yes" ; then
   tar -xjf ./packages/scws-${new_version}.tar.bz2
   cd scws-$new_version
   echo "Configuring scws ..."
-  ./configure --prefix=$prefix >> ../setup.log 2>&1
+  if test -n "$freebsd" then
+    ./configure --host=x86_64-xunsearch-kfreebsd-gnu --prefix=$prefix >> ../setup.log 2>&1
+  else 
+    ./configure --prefix=$prefix >> ../setup.log 2>&1
+  fi
   if test $? -ne 0 ; then
     setup_abort "configure scws"
   fi

--- a/xunsearch-full/setup.sh
+++ b/xunsearch-full/setup.sh
@@ -48,7 +48,7 @@ set_force="no"
 set_no_clean="no"
 mk_add_option=
 xs_add_option=
-freebsd=`uname -a | grep FreeBSD`
+os=`uname -s`
 
 i=0
 while [ $i -lt $# ] ; do
@@ -139,13 +139,12 @@ prefix=$set_prefix
 echo $prefix > $HOME/.xs_installed
 
 # compile flags
-if test -n "$freebsd"; then
-  export CFLAGS="-O2 -fPIC"
-  export CXXFLAGS="-O2 -fPIC"
-else 
-  export CFLAGS="-O2"
-  export CXXFLAGS="-O2"
+CFLAGS=-O2
+if test "$os" = "FreeBSD"; then
+   CFLAGS="$CFLAGS -fPIC"
 fi
+export CFLAGS=$CFLAGS
+export CXXFLAGS=$CFLAGS
 echo -n > setup.log
 
 # error function
@@ -190,7 +189,7 @@ if test "$do_install" = "yes" ; then
   tar -xjf ./packages/scws-${new_version}.tar.bz2
   cd scws-$new_version
   echo "Configuring scws ..."
-  if test -n "$freebsd" ; then
+  if test "$os" = "FreeBSD"; then
     ./configure --host=x86_64-xunsearch-kfreebsd-gnu --prefix=$prefix >> ../setup.log 2>&1
   else 
     ./configure --prefix=$prefix >> ../setup.log 2>&1

--- a/xunsearch-full/setup.sh
+++ b/xunsearch-full/setup.sh
@@ -48,7 +48,7 @@ set_force="no"
 set_no_clean="no"
 mk_add_option=
 xs_add_option=
-freebsd= `uname -a | grep FreeBSD`
+freebsd=`uname -a | grep FreeBSD`
 
 i=0
 while [ $i -lt $# ] ; do
@@ -139,7 +139,7 @@ prefix=$set_prefix
 echo $prefix > $HOME/.xs_installed
 
 # compile flags
-if test -n "$freebsd" then
+if test -n "$freebsd"; then
   export CFLAGS="-O2 -fPIC"
   export CXXFLAGS="-O2 -fPIC"
 else 
@@ -190,7 +190,7 @@ if test "$do_install" = "yes" ; then
   tar -xjf ./packages/scws-${new_version}.tar.bz2
   cd scws-$new_version
   echo "Configuring scws ..."
-  if test -n "$freebsd" then
+  if test -n "$freebsd" ; then
     ./configure --host=x86_64-xunsearch-kfreebsd-gnu --prefix=$prefix >> ../setup.log 2>&1
   else 
     ./configure --prefix=$prefix >> ../setup.log 2>&1


### PR DESCRIPTION
解决了scws在freebsd下编译无法生成so的问题，优化了写法,在freebsd 10.2 x64上测试通过，32位上因无环境，所以没办法进行测试，但应该不致于出错，如果在bsd下安装有任何问题，还是在群里吼我一下下