### PR TITLE
必须在sql中指定limit限制，避免sql自动获取count数量出错。

### DIFF
--- a/sdk/php/util/XSDataSource.class.php
+++ b/sdk/php/util/XSDataSource.class.php
@@ -202,9 +202,7 @@ class XSDatabaseDataSource extends XSDataSource
 
 		$this->sql = $sql;
 		if ($this->limit == 0) {
-			$sql = preg_replace('/SELECT\s+.+?\sFROM\s/is', 'SELECT COUNT(*) AS count FROM ', $sql);
-			$res = $this->db->query1($sql);
-			$this->limit = $res['count'] - $this->offset;
+			throw new XSException("must specified `limit` parameter in sql statement");
 		}
 	}
 


### PR DESCRIPTION
比如在select count(b.id) from t1 a left join t2 b on a.id = b.t1_id group by a.id;时自动判断count的语句会不按预期运行，去掉更好？