### PR TITLE
修复PHP-SDK文档链接失效的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Xunsearch 全面开源，并使用最流行的开源许可协议 GPL 发布。�
 SDK 开发文档
 -----------
 
-请阅读 [PHP-SDK 文档](sdk/php/README)
+请阅读 [PHP-SDK 文档](sdk/php/README.md)
 
 
 架构说明


### PR DESCRIPTION
Hi，大家好，我发现在项目的README.md文件中无法打开「PHP-SDK 文档」，故修复此问题。