### PR TITLE
增加Alapin Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,32 @@
+# 基于Alpine镜像去构建
+FROM alpine:3.13
+
+# 设定时区和工作目录
+ENV TZ Asia/Shanghai
+WORKDIR /usr/local/xunsearch
+
+# 安装迅搜
+RUN apk add --no-cache \
+    tzdata \
+    zlib-dev \
+    libgcc \
+    libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+    wget \
+    bzip2 \
+    make \
+    g++ \
+    gcc \
+    && wget -qO - http://www.xunsearch.com/download/xunsearch-full-latest.tar.bz2 | tar xj \
+    && cd xunsearch-full-* && sh setup.sh --prefix=/usr/local/xunsearch \
+    && cd .. && rm -rf xunsearch-full-* && apk del .build-deps && rm -rf /var/cache/apk/*
+
+# 暴露端口
+EXPOSE 8383
+EXPOSE 8384
+
+#启动脚本
+COPY docker-entrypoint.sh docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+CMD ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo 'start xunsearch'
+rm -f tmp/pid.* && bin/xs-indexd -l /dev/stdout -k start && bin/xs-searchd -l /dev/stdout -k start && tail -f /dev/null


### PR DESCRIPTION
使用了Alpine去构建镜像，可以使镜像大小缩减到42M。
日志直接输出到了`/dev/stdout`里面，不再像官方镜像写入到文件里。
编译的时候使用`docker build -f ./Dockerfile.alpine --name hightman/xunsearch:alpine .` 去构建即可。