### PR TITLE
PHP 8.1 compatibility fixes for PHP SDK

### DIFF
--- a/sdk/php/lib/XSDocument.class.php
+++ b/sdk/php/lib/XSDocument.class.php
@@ -269,6 +269,7 @@ class XSDocument implements ArrayAccess, IteratorAggregate
 	/**
 	 * IteratorAggregate 接口, 以支持 foreach 遍历访问字段列表
 	 */
+	#[ReturnTypeWillChange]
 	public function getIterator()
 	{
 		if ($this->_charset !== null && $this->_charset !== 'UTF-8') {
@@ -284,6 +285,7 @@ class XSDocument implements ArrayAccess, IteratorAggregate
 	 * @param string $name 字段名称
 	 * @return bool 存在返回 true, 若不存在返回 false
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists($name)
 	{
 		return isset($this->_data[$name]);
@@ -306,6 +308,7 @@ class XSDocument implements ArrayAccess, IteratorAggregate
 	 * @param mixed $value 字段值
 	 * @see __set
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet($name, $value)
 	{
 		if (!is_null($name)) {
@@ -317,6 +320,7 @@ class XSDocument implements ArrayAccess, IteratorAggregate
 	 * ArrayAccess 接口, 删除字段值, 勿直接调用
 	 * @param string $name 字段名称
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset($name)
 	{
 		unset($this->_data[$name]);

--- a/sdk/php/lib/XSFieldScheme.class.php
+++ b/sdk/php/lib/XSFieldScheme.class.php
@@ -186,6 +186,7 @@ class XSFieldScheme implements IteratorAggregate
 	/**
 	 * IteratorAggregate 接口, 以支持 foreach 遍历访问所有字段
 	 */
+	#[ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new ArrayIterator($this->_fields);


### PR DESCRIPTION
PHP SDK 在 PHP 8.1 下会产生 Deprecated 报错，参考：

- [PHP 8.1: Return types in PHP built-in class methods and deprecation notices](https://php.watch/versions/8.1/internal-method-return-types)
- [PHP 8.1: New #[ReturnTypeWillChange] attribute](https://php.watch/versions/8.1/ReturnTypeWillChange)