### PR TITLE
php-fpm环境下,max_execution_time 的值可能是 max_execution_time=30s

### DIFF
--- a/sdk/php/lib/XSServer.class.php
+++ b/sdk/php/lib/XSServer.class.php
@@ -478,7 +478,7 @@ class XSServer extends XSComponent
 		}
 
 		// set socket options
-		$timeout = ini_get('max_execution_time');
+		$timeout = (int)trim(ini_get('max_execution_time'),'s');
 		$timeout = $timeout > 0 ? ($timeout - 1) : 30;
 		stream_set_blocking($sock, true);
 		stream_set_timeout($sock, $timeout);

--- a/sdk/php/lib/XSServer.class.php
+++ b/sdk/php/lib/XSServer.class.php
@@ -478,7 +478,7 @@ class XSServer extends XSComponent
 		}
 
 		// set socket options
-		$timeout = (int)trim(ini_get('max_execution_time'),'s');
+		$timeout = intval(ini_get('max_execution_time'));
 		$timeout = $timeout > 0 ? ($timeout - 1) : 30;
 		stream_set_blocking($sock, true);
 		stream_set_timeout($sock, $timeout);


### PR DESCRIPTION
php-fpm环境下,max_execution_time 的值可能是 max_execution_time=30s, 会导致$timeout > 0 出错