### PR TITLE
Enhance import error handling and rebuild safety measures

### DIFF
--- a/src/import.cc
+++ b/src/import.cc
@@ -924,6 +924,7 @@ int main(int argc, char *argv[])
 	// check to archive
 	if ((flag & FLAG_DEFAULT_DB) && (database.get_doccount() >= DEFAULT_ARCHIVE_THRESHOLD)) {
 		char *ptr = strrchr(db_path, '/');
+		int arc_ok = 0;
 
 		log_alert("compact the database into archive (DB:%s, TOTAL:%d)", db_path, database.get_doccount());
 		if (ptr != NULL) {
@@ -935,31 +936,62 @@ int main(int argc, char *argv[])
 		if (flag & FLAG_ARCHIVE) {
 			archive.close();
 
-			// 1. merge: db_a + db -> db_c
-			log_info("rm -rf db_c");
-			system("/bin/rm -rf " DEFAULT_DB_NAME "_c");
-			log_info("xapian-compact db + db_a = db_c");
-			system(XAPIAN_DIR "/bin/xapian-compact -n " DEFAULT_DB_NAME "_a " DEFAULT_DB_NAME " " DEFAULT_DB_NAME "_c");
-			// 2. remove: db_o db
-			log_info("rm -rf db_o db");
-			system("/bin/rm -rf " DEFAULT_DB_NAME "_o " DEFAULT_DB_NAME);
-			// 3. rename: db_a -> db_o, db_c -> db_a
+			// 1. clean stale intermediate dirs from previous failed attempts
+			log_info("rm -rf db_c db_o");
+			system("/bin/rm -rf " DEFAULT_DB_NAME "_c " DEFAULT_DB_NAME "_o");
+
+			// 2. merge: db_a + db -> db_c
+			log_info("xapian-compact db_a + db = db_c");
+			if (system(XAPIAN_DIR "/bin/xapian-compact -n " DEFAULT_DB_NAME "_a " DEFAULT_DB_NAME " " DEFAULT_DB_NAME "_c") != 0) {
+				log_error("xapian-compact failed, abort archive");
+				goto arc_end;
+			}
+
+			// 3. rotate: db_a -> db_o (backup old archive)
 			log_info("mv -f db_a db_o");
-			system("/bin/mv -f " DEFAULT_DB_NAME "_a " DEFAULT_DB_NAME "_o");
+			if (system("/bin/mv -f " DEFAULT_DB_NAME "_a " DEFAULT_DB_NAME "_o") != 0) {
+				log_error("failed to move db_a to db_o, abort archive");
+				goto arc_end;
+			}
+
+			// 4. promote: db_c -> db_a (new archive in place)
 			log_info("mv -f db_c db_a");
-			system("/bin/mv -f " DEFAULT_DB_NAME "_c " DEFAULT_DB_NAME "_a");
+			if (system("/bin/mv -f " DEFAULT_DB_NAME "_c " DEFAULT_DB_NAME "_a") != 0) {
+				log_error("failed to move db_c to db_a, attempt rollback db_o -> db_a");
+				if (system("/bin/mv -f " DEFAULT_DB_NAME "_o " DEFAULT_DB_NAME "_a") != 0) {
+					log_error("rollback also failed, db_a missing! manual recovery needed from db_o");
+				}
+				goto arc_end;
+			}
+
+			// 5. new archive is safe, now remove old backup
+			log_info("rm -rf db_o");
+			system("/bin/rm -rf " DEFAULT_DB_NAME "_o");
+
+			// 6. remove old db (its data is now merged into db_a)
+			log_info("rm -rf db");
+			if (system("/bin/rm -rf " DEFAULT_DB_NAME) != 0) {
+				log_error("failed to remove old db after archive, search may return duplicates");
+			}
+			arc_ok = 1;
 		} else {
-			// 1. remove: db_a (clean)
-			log_info("rm -rf db_a");
-			system("/bin/rm -rf " DEFAULT_DB_NAME "_a");
-			// 2. rename: db -> db_a
+			// no existing archive: just rename db -> db_a
 			log_info("mv -f db db_a");
-			system("/bin/mv -f " DEFAULT_DB_NAME " " DEFAULT_DB_NAME "_a");
+			if (system("/bin/mv -f " DEFAULT_DB_NAME " " DEFAULT_DB_NAME "_a") != 0) {
+				log_error("failed to move db to db_a, abort archive");
+				goto arc_end;
+			}
+			arc_ok = 1;
 		}
 
-		// re-create empty db
-		log_info("re-create the empty default db");
-		database = Xapian::WritableDatabase(DEFAULT_DB_NAME, Xapian::DB_CREATE_OR_OPEN);
+arc_end:
+		if (arc_ok) {
+			// re-create empty db
+			log_info("re-create the empty default db");
+			database = Xapian::WritableDatabase(DEFAULT_DB_NAME, Xapian::DB_CREATE_OR_OPEN);
+		} else {
+			log_error("archive aborted, database left as-is to avoid data loss");
+		}
 	}
 	database.close();
 

--- a/src/import.cc
+++ b/src/import.cc
@@ -986,10 +986,34 @@ int main(int argc, char *argv[])
 
 arc_end:
 		if (arc_ok) {
-			// re-create empty db
-			log_info("re-create the empty default db");
-			database = Xapian::WritableDatabase(DEFAULT_DB_NAME, Xapian::DB_CREATE_OR_OPEN);
+			// re-create empty db with retry for transient lock conflicts
+			// (searchd workers may briefly hold read locks on the db path during reopen)
+			int retry;
+			for (retry = 0; retry < 3; retry++) {
+				try {
+					log_info("re-create the empty default db (ATTEMPT:%d/3)", retry + 1);
+					if (retry > 0) {
+						sleep(1);
+					}
+					database = Xapian::WritableDatabase(DEFAULT_DB_NAME, Xapian::DB_CREATE_OR_OPEN);
+					break;
+				} catch (const Xapian::DatabaseLockError &e) {
+					log_error("lock conflict creating empty db (ATTEMPT:%d/3, ERROR:%s)",
+							retry + 1, e.get_msg().data());
+				} catch (const Xapian::Error &e) {
+					log_error("failed to re-create empty db (ATTEMPT:%d/3, ERROR:%s)",
+							retry + 1, e.get_msg().data());
+					break; // non-lock errors: no point retrying
+				}
+			}
+			if (retry >= 3) {
+				log_error("CRITICAL: empty db creation failed after 3 attempts, "
+						"archive data is safe in db_a, db will be re-created on next import");
+				flag |= FLAG_TERMINATED; // signal non-zero exit to indexd
+			}
 		} else {
+			// archive is an optimization, does not affect imported data (already in db)
+			// do not set FLAG_TERMINATED: import itself succeeded, only archive failed
 			log_error("archive aborted, database left as-is to avoid data loss");
 		}
 	}

--- a/src/import.cc
+++ b/src/import.cc
@@ -933,12 +933,41 @@ int main(int argc, char *argv[])
 		}
 
 		database.close();
+
+		// if db_a is missing but db_o exists (previous failed archive), restore it
+		// NOTE: this check must happen BEFORE FLAG_ARCHIVE test, because FLAG_ARCHIVE
+		// is only set when db_a was successfully opened at startup. In the exact
+		// failure scenario we're recovering from (db_a lost, only db_o remains),
+		// FLAG_ARCHIVE would be false.
+		if (!(flag & FLAG_ARCHIVE)
+				&& access(DEFAULT_DB_NAME "_a", R_OK) != 0
+				&& access(DEFAULT_DB_NAME "_o", R_OK) == 0) {
+			log_notice("db_a missing but db_o found, restoring from previous backup");
+			if (system("/bin/mv -f " DEFAULT_DB_NAME "_o " DEFAULT_DB_NAME "_a") != 0) {
+				log_error("failed to restore db_o -> db_a, abort archive");
+				goto arc_end;
+			}
+			// re-open restored archive and set flag so compact path is taken
+			try {
+				archive = Xapian::WritableDatabase(DEFAULT_DB_NAME "_a", Xapian::DB_OPEN);
+				flag |= FLAG_ARCHIVE;
+				log_notice("restored archive database opened successfully");
+			} catch (const Xapian::Error &e) {
+				// db_a was just restored from db_o and is the last recoverable copy.
+				// Do NOT continue with archive flow — leave db_a for manual recovery.
+				log_error("failed to open restored archive (ERROR:%s), abort to preserve db_a",
+						e.get_msg().data());
+				goto arc_end;
+			}
+		}
+
 		if (flag & FLAG_ARCHIVE) {
 			archive.close();
 
-			// 1. clean stale intermediate dirs from previous failed attempts
-			log_info("rm -rf db_c db_o");
-			system("/bin/rm -rf " DEFAULT_DB_NAME "_c " DEFAULT_DB_NAME "_o");
+			// 1. clean stale intermediate db_c from previous failed attempts
+			// NOTE: keep db_o as recovery fallback until compact succeeds
+			log_info("rm -rf db_c");
+			system("/bin/rm -rf " DEFAULT_DB_NAME "_c");
 
 			// 2. merge: db_a + db -> db_c
 			log_info("xapian-compact db_a + db = db_c");
@@ -947,14 +976,16 @@ int main(int argc, char *argv[])
 				goto arc_end;
 			}
 
-			// 3. rotate: db_a -> db_o (backup old archive)
+			// 4. rotate: compact succeeded (db_c is safe), now clear old db_o and rotate
+			log_info("rm -rf db_o");
+			system("/bin/rm -rf " DEFAULT_DB_NAME "_o");
 			log_info("mv -f db_a db_o");
 			if (system("/bin/mv -f " DEFAULT_DB_NAME "_a " DEFAULT_DB_NAME "_o") != 0) {
 				log_error("failed to move db_a to db_o, abort archive");
 				goto arc_end;
 			}
 
-			// 4. promote: db_c -> db_a (new archive in place)
+			// 5. promote: db_c -> db_a (new archive in place)
 			log_info("mv -f db_c db_a");
 			if (system("/bin/mv -f " DEFAULT_DB_NAME "_c " DEFAULT_DB_NAME "_a") != 0) {
 				log_error("failed to move db_c to db_a, attempt rollback db_o -> db_a");
@@ -963,10 +994,6 @@ int main(int argc, char *argv[])
 				}
 				goto arc_end;
 			}
-
-			// 5. new archive is safe, now remove old backup
-			log_info("rm -rf db_o");
-			system("/bin/rm -rf " DEFAULT_DB_NAME "_o");
 
 			// 6. remove old db (its data is now merged into db_a)
 			log_info("rm -rf db");
@@ -1009,7 +1036,9 @@ arc_end:
 			if (retry >= 3) {
 				log_error("CRITICAL: empty db creation failed after 3 attempts, "
 						"archive data is safe in db_a, db will be re-created on next import");
-				flag |= FLAG_TERMINATED; // signal non-zero exit to indexd
+				// NOTE: do NOT set FLAG_TERMINATED here. Archive already succeeded and
+				// data is safe in db_a. A non-zero exit would cause indexd to keep the
+				// .snd file for retry, leading to duplicate data import.
 			}
 		} else {
 			// archive is an optimization, does not affect imported data (already in db)

--- a/src/import.cc
+++ b/src/import.cc
@@ -426,6 +426,12 @@ static int doc_fetch()
 			log_info("~skip to add/del synonyms (TERM:%.*s, SKIP_LEFT:%d)",
 					cmd.blen, term + 1, num_skip - total - 1);
 		} else {
+			if (size < (cmd.blen + cmd.blen1)) {
+				log_error("invalid synonyms command size (SIZE:%d, BLEN:%d, BLEN1:%d)",
+						size, cmd.blen, cmd.blen1);
+				rc = FETCH_ABORT;
+				goto doc_end;
+			}
 			string org_term = Xapian::Unicode::tolower(string(term + 1, cmd.blen));
 			string syn_term = Xapian::Unicode::tolower(string(term + cmd.blen + 1, cmd.blen1));
 #ifdef HAVE_SYNONYMS_STEM
@@ -581,7 +587,16 @@ static int doc_fetch()
 				}
 				// save first value as ID term for logging
 				if (term == NULL) {
-					term = strdup(buf);
+					if (size > 0 && buf != NULL) {
+						term = strdup(buf);
+						if (term == NULL) {
+							rc = FETCH_ABORT;
+							log_error("failed to duplicate doc value for term (SIZE:%d)", size);
+							goto doc_end;
+						}
+					} else {
+						log_notice("skip empty first doc value for term");
+					}
 				}
 				break;
 			case CMD_DOC_INDEX:

--- a/src/indexd.c
+++ b/src/indexd.c
@@ -64,6 +64,8 @@ static char xs_import[128], xs_logging[128], *prog_name;
 static volatile int main_flag, import_num;
 
 static int safe_write(int fd, void *buf, int size);
+static inline void update_eff_size(int fd);
+static inline void check_eff_size(int fd);
 
 /**
  * Show version information

--- a/src/indexd.c
+++ b/src/indexd.c
@@ -219,7 +219,6 @@ static void db_import_call(XS_DB *db, XS_USER *user)
 
 		// check to commit older file first
 		suffix = rcvfile + sprintf(rcvfile, DEFAULT_TEMP_DIR "%s_%s.rcv", user->name, db->name);
-#if SIZEOF_OFF_T < 8
 		for (i = MAX_SPLIT_FILES; i > 0; i--) {
 			sprintf(suffix, ".%d", i);
 			if (!access(rcvfile, R_OK)) {
@@ -233,7 +232,6 @@ static void db_import_call(XS_DB *db, XS_USER *user)
 				break;
 			}
 		}
-#endif	/* LARGEFILE */
 
 		// use new rcvfile
 		if (i == 0) {
@@ -726,7 +724,6 @@ static inline void check_eff_size(int fd)
 static inline void clean_uncommitted_data(XS_DB *db, XS_USER *user)
 {
 	// clean splitted file
-#if SIZEOF_OFF_T < 8
 	int i = 0;
 	char fpath[256], *suffix;
 
@@ -738,7 +735,6 @@ static inline void clean_uncommitted_data(XS_DB *db, XS_USER *user)
 			unlink(fpath);
 		}
 	}
-#endif	/* LARGEFILE */
 
 	// clean current file
 	lseek(db->fd, 0, SEEK_SET);
@@ -974,7 +970,6 @@ static int save_conn_request(XS_CONN *conn)
 		log_notice_conn("auto commit (DB:%s.%s, COUNT:%d)", conn->user->name, db->name, db->count);
 		db_import_call(db, conn->user);
 	}
-#if SIZEOF_OFF_T < 8
 	else if ((db->count - db->lcount) > queue_size) // check to split
 	{
 		struct stat st;
@@ -990,22 +985,27 @@ static int save_conn_request(XS_CONN *conn)
 			suffix = rcvfile2 + strlen(rcvfile2);
 
 			do {
-				sprintf(suffix, ".%d", i++);
-			} while (access(rcvfile2, R_OK) == 0);
+				sprintf(suffix, ".%d", i);
+			} while (access(rcvfile2, R_OK) == 0 && ++i <= MAX_SPLIT_FILES);
 
-			log_notice_conn("auto split data (FILE:%s, COUNT:%d)", rcvfile2, db->count);
-			close(db->fd);
-			db->fd = -1;
-			db->count = db->lcount = 0;
+			if (access(rcvfile2, R_OK) == 0) {
+				// all slots 1..MAX_SPLIT_FILES occupied
+				log_error_conn("too many split files, stop splitting (DB:%s.%s, MAX:%d)",
+						conn->user->name, db->name, MAX_SPLIT_FILES);
+			} else {
+				log_notice_conn("auto split data (FILE:%s, COUNT:%d)", rcvfile2, db->count);
+				close(db->fd);
+				db->fd = -1;
+				db->count = db->lcount = 0;
 
-			// rename the file
-			if (rename(rcvfile, rcvfile2) != 0) {
-				log_error_conn("failed to rename splitted file (FILE:%s, ERROR:%s)",
-						rcvfile2, strerror(errno));
+				// rename the file
+				if (rename(rcvfile, rcvfile2) != 0) {
+					log_error_conn("failed to rename splitted file (FILE:%s, ERROR:%s)",
+							rcvfile2, strerror(errno));
+				}
 			}
 		}
 	}
-#endif	/* LAREFILE */
 
 	// finished
 	rc = CONN_RES_OK(RQST_FINISHED);

--- a/src/indexd.c
+++ b/src/indexd.c
@@ -63,6 +63,8 @@ static int queue_size;
 static char xs_import[128], xs_logging[128], *prog_name;
 static volatile int main_flag, import_num;
 
+static int safe_write(int fd, void *buf, int size);
+
 /**
  * Show version information
  */
@@ -153,6 +155,64 @@ static void db_import_call(XS_DB *db, XS_USER *user)
 	// check old send file first
 	if (access(sndfile, R_OK) == 0) {
 		log_notice("priority use unfinished sndfile (FILE:%s)", sndfile);
+		if (db->count > 0 && db->fd >= 0) {
+			char rcvfile[128];
+			char buf[8192];
+			int rfd, sfd, n;
+			off_t hdr_size = sizeof(XS_CMD) + sizeof(struct xs_import_hdr);
+
+			sprintf(rcvfile, DEFAULT_TEMP_DIR "%s_%s.rcv", user->name, db->name);
+			close(db->fd);
+			db->fd = -1;
+
+			if ((rfd = open(rcvfile, O_RDONLY)) >= 0) {
+				if ((sfd = open(sndfile, O_RDWR)) >= 0) {
+					off_t snd_orig_size;
+					check_eff_size(rfd);
+					check_eff_size(sfd);
+					lseek(rfd, hdr_size, SEEK_SET);
+					snd_orig_size = lseek(sfd, 0, SEEK_END);
+
+					while ((n = read(rfd, buf, sizeof(buf))) > 0) {
+						if (safe_write(sfd, buf, n) != 0) {
+							log_error("failed to append rcvfile into sndfile (SRC:%s, DST:%s, ERROR:%s)",
+									rcvfile, sndfile, strerror(errno));
+							break;
+						}
+					}
+					if (n < 0) {
+						log_error("failed to read rcvfile for append (FILE:%s, ERROR:%s)",
+								rcvfile, strerror(errno));
+					}
+					if (n != 0) {
+						// read or write failed: rollback sndfile to original size
+						// to prevent duplicate data on next retry
+						log_notice("rollback sndfile to original size (FILE:%s, SIZE:%ld)",
+								sndfile, (long) snd_orig_size);
+						ftruncate(sfd, snd_orig_size);
+					} else {
+						update_eff_size(sfd);
+						if (unlink(rcvfile) == 0 || errno == ENOENT) {
+							log_notice("merged pending rcvfile into sndfile (SRC:%s, DST:%s, COUNT:%d)",
+									rcvfile, sndfile, db->count);
+							db->count = db->lcount = 0;
+							db->flag &= ~XS_DBF_FORCE_COMMIT;
+						} else {
+							log_error("failed to remove merged rcvfile (FILE:%s, ERROR:%s)",
+									rcvfile, strerror(errno));
+						}
+					}
+					close(sfd);
+				} else {
+					log_error("failed to open sndfile for append (FILE:%s, ERROR:%s)",
+							sndfile, strerror(errno));
+				}
+				close(rfd);
+			} else {
+				log_error("failed to open rcvfile for append (FILE:%s, ERROR:%s)",
+						rcvfile, strerror(errno));
+			}
+		}
 	} else {
 		char rcvfile[128], *suffix;
 		int i = 0;
@@ -435,8 +495,20 @@ static void rebuild_wdb_end(XS_DB *db, XS_USER *user)
 	sprintf(dbpath, "%s/%s", user->home, db->name);
 	log_info("rebuild finished, rename db (PATH:%s -> %s)", dbre, dbpath);
 	if (rmdir_r(dbpath) != 0 || rename(dbre, dbpath) != 0) {
+		char badpath[280];
 		log_error("failed to rename rebuilt database (DB:%s.%s, ERROR:%s)",
 				user->name, db->name, strerror(errno));
+		// preserve db.re for manual recovery, rename to .bad.<timestamp>
+		snprintf(badpath, sizeof(badpath), "%s.bad.%ld", dbre, (long) time(NULL));
+		if (rename(dbre, badpath) == 0) {
+			log_error("rebuilt database preserved for recovery (PATH:%s)", badpath);
+		} else {
+			log_error("failed to preserve rebuilt database (SRC:%s, DST:%s, ERROR:%s)",
+					dbre, badpath, strerror(errno));
+		}
+		db->flag &= ~XS_DBF_REBUILD_MASK;
+		db->flag |= XS_DBF_FORCE_COMMIT;
+		return;
 	}
 
 	// clean db_a
@@ -477,9 +549,9 @@ void signal_child(pid_t pid, int status)
 	time(&db->ltime);
 
 	// logging
-	log_notice("import exit (DB:%s.%s%s, FLAG:0x%04x, PID:%d, EXIT:%d)",
-			user->name, db->name, (db->flag & XS_DBF_REBUILD_BEGIN ? ".re" : ""), db->flag, pid, status);
 	sprintf(sndfile, DEFAULT_TEMP_DIR "%s_%s.snd", user->name, db->name);
+	log_notice("import exit (DB:%s.%s%s, FLAG:0x%04x, PID:%d, EXIT:%d, SND:%s)",
+			user->name, db->name, (db->flag & XS_DBF_REBUILD_BEGIN ? ".re" : ""), db->flag, pid, status, sndfile);
 
 	// check result
 	if (db->flag & XS_DBF_TOCLEAN) {
@@ -522,6 +594,7 @@ void signal_child(pid_t pid, int status)
 		log_notice("rebuild marked database (DB:%s.%s)", user->name, db->name);
 	} else if (status == 0) {
 		// quit normal, remove sndfile
+		db->import_fail = 0;
 		if (unlink(sndfile) != 0) {
 			log_error("failed to remove sndfile (PATH:%s, ERROR:%s)", sndfile, strerror(errno));
 		}
@@ -531,7 +604,35 @@ void signal_child(pid_t pid, int status)
 			rebuild_wdb_end(db, user);
 		}
 	} else {
-		// quit excepional, keep sndfile for next trying
+		// quit exceptional, keep sndfile for next trying
+		db->import_fail++;
+		log_error("import exited abnormally (DB:%s.%s, STATUS:%d, FILE:%s, FAIL_COUNT:%d/%d)",
+				user->name, db->name, status, sndfile, db->import_fail, MAX_IMPORT_FAIL);
+		if (db->import_fail >= MAX_IMPORT_FAIL) {
+			char badfile[280];
+			snprintf(badfile, sizeof(badfile), "%s.bad.%ld", sndfile, (long) time(NULL));
+			log_error("too many consecutive import failures, preserve sndfile (DB:%s.%s, FILE:%s -> %s)",
+					user->name, db->name, sndfile, badfile);
+			if (rename(sndfile, badfile) != 0) {
+				log_error("failed to rename sndfile (SRC:%s, DST:%s, ERROR:%s)",
+						sndfile, badfile, strerror(errno));
+			}
+			db->import_fail = 0;
+			// if rebuilding, abort the rebuild to avoid stuck state
+			if (db->flag & XS_DBF_REBUILD_BEGIN) {
+				char repath[256], badrepath[280];
+				sprintf(repath, "%s/%s.re", user->home, db->name);
+				snprintf(badrepath, sizeof(badrepath), "%s.bad.%ld", repath, (long) time(NULL));
+				log_error("abort stuck rebuild due to repeated failures (DB:%s.%s, PATH:%s -> %s)",
+						user->name, db->name, repath, badrepath);
+				if (rename(repath, badrepath) != 0) {
+					log_error("failed to rename rebuilt database (SRC:%s, DST:%s, ERROR:%s)",
+							repath, badrepath, strerror(errno));
+				}
+				db->flag &= ~XS_DBF_REBUILD_MASK;
+				db->flag |= XS_DBF_FORCE_COMMIT;
+			}
+		}
 	}
 }
 
@@ -668,10 +769,21 @@ static int rebuild_conn_wdb(XS_CONN *conn)
 			log_debug_conn("clean uncommitted data for rebuilding");
 			clean_uncommitted_data(db, conn->user);
 		}
-		if (db->pid > 0 && !(db->flag & XS_DBF_TOCLEAN) && !kill(db->pid, SIGTERM)) {
-			// BUG: if import exit normal HERE may cause some problem
+		if (db->pid > 0 && !(db->flag & XS_DBF_TOCLEAN)) {
+			// set flag BEFORE kill to avoid race with signal_child
 			db->flag |= XS_DBF_REBUILD_WAIT;
-			log_notice_conn("notify running import to quit & set rebuild_wait flag");
+			if (kill(db->pid, SIGTERM) != 0) {
+				// process already gone, clear flag and clean manually
+				db->flag &= ~XS_DBF_REBUILD_WAIT;
+				char repath[256];
+				sprintf(repath, "%s/%s.re", conn->user->home, db->name);
+				if (!access(repath, R_OK)) {
+					log_notice("clean exists rebuilt database (PATH:%s)", repath);
+					rmdir_r(repath);
+				}
+			} else {
+				log_notice_conn("notify running import to quit & set rebuild_wait flag");
+			}
 		} else {
 			// clean exists rebuild db
 			char repath[256];

--- a/src/indexd.h
+++ b/src/indexd.h
@@ -16,9 +16,11 @@
 #define	MAX_IMPORT_NUM			5			// number of concurrent import processes
 #define	MAX_IMPORT_FAIL			3			// max consecutive import failures before discarding sndfile
 
-#if SIZEOF_OFF_T < 8
 #define	MAX_SPLIT_FILES			10			// max split files (xxx_xx.rcv.[NUM])
-#define	MAX_SPLIT_SIZE			1610612736L	// 1.5GB
-#endif	/* LARG FILE */
+#if SIZEOF_OFF_T < 8
+#define	MAX_SPLIT_SIZE			1610612736L	// 1.5GB for 32-bit
+#else
+#define	MAX_SPLIT_SIZE			((off_t)2147483648)	// 2GB for 64-bit
+#endif
 
 #endif	/* __XS_INDEXD_20090530_H__ */

--- a/src/indexd.h
+++ b/src/indexd.h
@@ -14,6 +14,7 @@
 #define	MIN_COMMIT_COUNT		100			// number of changed
 #define	MIN_COMMIT_TIME			180			// seconds
 #define	MAX_IMPORT_NUM			5			// number of concurrent import processes
+#define	MAX_IMPORT_FAIL			3			// max consecutive import failures before discarding sndfile
 
 #if SIZEOF_OFF_T < 8
 #define	MAX_SPLIT_FILES			10			// max split files (xxx_xx.rcv.[NUM])

--- a/src/task.cc
+++ b/src/task.cc
@@ -495,8 +495,35 @@ static int send_result_doc(XS_CONN *conn, struct result_doc *rd, struct search_r
 			}
 			rc = conn_respond(conn, CMD_SEARCH_RESULT_MATCHED, 0, data.data(), data.size());
 		}
+	} catch (const Xapian::DatabaseError &e) {
+		// database is corrupted or replaced
+		// rate-limit logging: at most once per 60 seconds
+		static time_t last_db_error_log = 0;
+		static int db_error_count = 0;
+		time_t now = time(NULL);
+
+		db_error_count++;
+		if (now - last_db_error_log >= 60) {
+			if (db_error_count > 1) {
+				log_error_conn("xapian database error on sending doc, %d errors in last 60s (ERROR:%s)",
+						db_error_count, e.get_msg().data());
+			} else {
+				log_error_conn("xapian database error on sending doc (ERROR:%s)", e.get_msg().data());
+			}
+			last_db_error_log = now;
+			db_error_count = 0;
+		}
+
+		if (cr != NULL) {
+#ifdef HAVE_MEMORY_CACHE
+			cr->count = cr->lastid = 0;
+#endif
+		}
+		// return error to break the send loop and disconnect.
+		// on reconnect, the new session will re-initialize via fetch_conn_database()
+		// which handles corrupted/replaced databases with its reopen-with-fallback path.
+		rc = CMD_RES_ERROR;
 	} catch (const Xapian::Error &e) {
-		// ignore the error simply
 		log_error_conn("xapian exception on sending doc (ERROR:%s)", e.get_msg().data());
 		if (cr != NULL) {
 #ifdef HAVE_MEMORY_CACHE
@@ -565,6 +592,35 @@ static void *zarg_get_object(struct search_zarg *zarg, enum object_type type, co
 		oc = oc->next;
 	}
 	return NULL;
+}
+
+/**
+ * Delete a cached object from zarg by type and key
+ * Used to discard a corrupted database handle so it can be reopened fresh
+ * @param zarg
+ * @param type
+ * @param key
+ */
+static void zarg_del_object(struct search_zarg *zarg, enum object_type type, const char *key)
+{
+	struct object_chain **pp = &zarg->objs;
+	while (*pp != NULL) {
+		struct object_chain *oc = *pp;
+		if (oc->type == type
+				&& ((oc->key == NULL && key == NULL)
+					|| (oc->key != NULL && key != NULL && !strcmp(oc->key, key)))) {
+			*pp = oc->next;
+			if (oc->type == OTYPE_DB) {
+				DELETE_PTT(oc->val, Xapian::Database *);
+			}
+			if (oc->key != NULL) {
+				free(oc->key);
+			}
+			debug_free(oc);
+			return;
+		}
+		pp = &oc->next;
+	}
 }
 
 /**
@@ -832,7 +888,18 @@ static inline Xapian::Database *fetch_conn_database(XS_CONN *conn, const char *n
 		zarg_add_object(zarg, OTYPE_DB, name, db);
 		log_debug_conn("new (Xapian::Database *) %p (KEY:%s)", db, name);
 	} else {
-		db->reopen();
+		try {
+			db->reopen();
+		} catch (const Xapian::DatabaseError &e) {
+			// reopen failed (database may have been replaced or corrupted)
+			// discard the old handle and open a fresh one
+			log_notice_conn("reopen failed, recreating database handle (KEY:%s, ERROR:%s)",
+					name, e.get_msg().data());
+			zarg_del_object(zarg, OTYPE_DB, name);
+			db = new Xapian::Database(string(conn->user->home) + "/" + string(name));
+			db->keep_alive();
+			zarg_add_object(zarg, OTYPE_DB, name, db);
+		}
 	}
 	return db;
 }

--- a/src/user.h
+++ b/src/user.h
@@ -41,6 +41,7 @@ typedef struct xs_db
 	int fd; // temp fd to save received data
 	int count; // count of uncommitted documents
 	int lcount; // last count of record point
+	int import_fail; // consecutive import failure count
 	pid_t pid; // pid of import process (0 -> not writing)
 	time_t ltime; // last commit time
 


### PR DESCRIPTION
This pull request introduces several robustness and error-handling improvements to the database import and archiving logic, especially around file operations, process management, and recovery from failures. It also enhances logging and makes the code more resilient to edge cases such as file corruption, repeated failures, and abnormal process exits. The changes affect both the import logic in `src/import.cc` and the index daemon in `src/indexd.c`, as well as related data structures and configuration in headers.

The most important changes are:

**Robustness and Error Handling in Import and Archiving:**
- Improved the database archive process to handle failures at each step (merging, renaming, promoting, and cleanup). Now, if any operation fails, the process aborts safely, attempts rollback where possible, and logs detailed errors to avoid data loss or leaving the system in an inconsistent state.
- Added validation for synonym command sizes and improved error handling in `doc_fetch()` to prevent buffer overflows or invalid memory access.
- Enhanced handling of abnormal import process exits: tracks consecutive failures, preserves problematic files for manual recovery after repeated failures, and aborts stuck rebuilds to avoid indefinite broken states. [[1]](diffhunk://#diff-0117e7a9d17172fa4ac1f0b13a9780e85ce787c07e61daea37551196cbac665eL534-R635) [[2]](diffhunk://#diff-eba17cbba3db864acd0642c378b6b203903a84992dbe5219799685f92a2dd761R44) [[3]](diffhunk://#diff-9c6ccbf46dcb951220800ea82db6c8a6a528c6f50b34a6415c4507b964004784R17-R24)

**File Management and Recovery Enhancements:**
- When merging unfinished received files (`rcvfile`) into send files (`sndfile`), added rollback logic to restore the original file state on failure, and improved cleanup to prevent duplicate or lost data.
- If a rebuilt database cannot be renamed into place, it is now preserved with a timestamped `.bad` suffix for manual recovery, and the rebuild flags are updated to avoid stuck states.

**Splitting and File Size Management:**
- Improved logic for splitting large files: enforces a maximum number of split files, logs errors if the limit is reached, and adapts split size limits based on system architecture (32-bit vs 64-bit). [[1]](diffhunk://#diff-0117e7a9d17172fa4ac1f0b13a9780e85ce787c07e61daea37551196cbac665eL881-R997) [[2]](diffhunk://#diff-9c6ccbf46dcb951220800ea82db6c8a6a528c6f50b34a6415c4507b964004784R17-R24)

**Process and Flag Management:**
- Refined process management during rebuilds: sets flags before killing processes to avoid race conditions, and cleans up orphaned rebuild directories if the import process is already gone.

**Logging and Diagnostics:**
- Enhanced logging throughout the import and archive processes, including more detailed context in log messages and tracking of abnormal exits, to aid in debugging and operational monitoring. [[1]](diffhunk://#diff-0117e7a9d17172fa4ac1f0b13a9780e85ce787c07e61daea37551196cbac665eL480-R554) [[2]](diffhunk://#diff-0117e7a9d17172fa4ac1f0b13a9780e85ce787c07e61daea37551196cbac665eR597)

These changes collectively make the import and archiving system more reliable, easier to debug, and safer against data loss or corruption.